### PR TITLE
Update alphtracker.json

### DIFF
--- a/data/alphtracker.json
+++ b/data/alphtracker.json
@@ -10,7 +10,7 @@
   "dotw": false,
   "councils_choice": true,
   "links": {
-    "website": "https://alphtracker.verify.diy",
+    "website": "https://www.alphtracker.org",
     "careers": "",
     "twitter": "",
     "telegram": "",


### PR DESCRIPTION
Update URL. Alphtracker now has a dedicated Domain.